### PR TITLE
Allow namespaced imports to be resolved correctly (to trigger travis build)

### DIFF
--- a/src/utils/__tests__/resolveToModule-test.js
+++ b/src/utils/__tests__/resolveToModule-test.js
@@ -90,5 +90,13 @@ describe('resolveToModule', () => {
       expect(resolveToModule(path)).toBe('Foo');
     });
 
+    it('resolves ImportNamespaceSpecifier', () => {
+      var path = parse(`
+        import * as foo from "Foo";
+        foo;
+      `);
+      expect(resolveToModule(path)).toBe('Foo');
+    });
+
   });
 });

--- a/src/utils/__tests__/resolveToValue-test.js
+++ b/src/utils/__tests__/resolveToValue-test.js
@@ -126,6 +126,15 @@ describe('resolveToValue', () => {
       expect(resolveToValue(path).node.type).toBe('ImportDeclaration');
     });
 
+    it('resolves namespace import references to the import declaration', () => {
+      var path = parse([
+        'import * as bar from "Foo"',
+        'bar;',
+      ].join('\n'));
+
+      expect(resolveToValue(path).node.type).toBe('ImportDeclaration');
+    });
+
   });
 
 });

--- a/src/utils/resolveToValue.js
+++ b/src/utils/resolveToValue.js
@@ -51,6 +51,7 @@ function findScopePath(paths: Array<NodePath>, path: NodePath): ?NodePath {
 
   if (types.ImportDefaultSpecifier.check(parentPath.node) ||
     types.ImportSpecifier.check(parentPath.node) ||
+    types.ImportNamespaceSpecifier.check(parentPath.node) ||
     types.VariableDeclarator.check(parentPath.node) ||
     types.TypeAlias.check(parentPath.node)
   ) {
@@ -84,6 +85,7 @@ export default function resolveToValue(path: NodePath): NodePath {
      }
   } else if (
     types.ImportDefaultSpecifier.check(node) ||
+    types.ImportNamespaceSpecifier.check(node) ||
     types.ImportSpecifier.check(node)
   ) {
     return path.parentPath;


### PR DESCRIPTION
Previously react-docgen did not resolve namespaced imports correctly to
their importing modules.
Example:

``` javascript
import * as React from 'react';
export default function Button({ text }) {
  return (<button>{text}</button>);
}
Button.propTypes = {
  text: React.PropTypes.string.isRequired,
};
```

The prop `text` would always show up as "custom" with a raw value of
"React.PropTypes.string.isRequired" instead of correctly detecting
`React.PropTypes.string` to be a part of the imported `React`
namespace and correctly detecting the propType as a required string.

This commit adds support for `ImportNamespaceSpecifier` to the
`resolveToValue` and `resolveToModule` utility functions.
